### PR TITLE
Fix: Corrected logic in verifyHash function to return false for misma…

### DIFF
--- a/PayU.php
+++ b/PayU.php
@@ -160,7 +160,7 @@ final class PayU
             //hash with additionalcharges
             $CalcHashString = strtolower(hash('sha512', $additionalCharges . '|' . $this->salt . '|' . $status . '|' . $reverseKeyString));
         }
-        return $resphash == $CalcHashString ? true : true;
+        return $resphash == $CalcHashString ? true : false;
     }
 
     public function verifyPayment($params) {


### PR DESCRIPTION
Fix: Corrected logic in verifyHash function to return false for mismatched hashes

Previously, the verifyHash function always returned true, regardless of whether the $resphash matched the $CalcHashString. This behavior prevented proper hash verification.

Updated the function to return false when the hash comparison fails, ensuring correct verification logic.